### PR TITLE
auto-detect OS, lowercase x for hexa numbers

### DIFF
--- a/jcp/makefile
+++ b/jcp/makefile
@@ -1,8 +1,3 @@
-# Compile for Windows(default)/Linux
-WIN=Windows
-LIN=Linux
-OS=$(WIN)
-
 # Compiler
 CC=gcc
 CFLAGS=-s -Wall
@@ -11,7 +6,7 @@ CFLAGS=-s -Wall
 JCPU=jcpu
 MCODE=mach_code
 
-ifeq ($(OS),$(WIN))
+ifeq ($(OS),Windows_NT)
 EXEC=.exe
 else
 EXEC=.bin

--- a/jcp/os_def.h
+++ b/jcp/os_def.h
@@ -2,7 +2,11 @@
 #ifndef OS_DEF_H
 #define OS_DEF_H
 // #define WINDOWS / LINUX
-#define WINDOWS
+#ifdef _WIN32
+# define WINDOWS
+#elif defined (__linux__)
+# define LINUX
+#endif
 
 #ifdef WINDOWS
 	#include <windows.h>


### PR DESCRIPTION
This makes disassembler output numbers with lower-case x like 0xFA instead 0XFA which is more confusing.

It also attempts to auto-detect OS so it compiles on Linux with just "make" without any manual modifications. 